### PR TITLE
chore: add profiling target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ clap = { version = "4.0", features = ["derive"] }
 toml = "0.8"
 tokio-tungstenite = "0.27.0"
 rayon = "1.7.0"
+
+[profile.profiling]
+inherits = "release"
+debug = true
+strip = false


### PR DESCRIPTION
# Description

Adds a new target `profiling`. without this, debug symbols wont be built into the application and therefore would be a lot harder to find hotspots.
It uses the `release` profile to have more accurate profiling

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

[this profile](https://share.firefox.dev/44p7ym7) helped track down overhead in [v0.17.0](https://github.com/Far-Beyond-Dev/Horizon/releases/tag/v0.17.0)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (not needed)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my chnages are stable (not needed)
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules (not needed)

