### PR TITLE
Non blocking sockets alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,8 @@ clap = { version = "4.0", features = ["derive"] }
 toml = "0.8"
 tokio-tungstenite = "0.27.0"
 rayon = "1.7.0"
+socket2 = "0.5.10"
+num_cpus = "1.13"
 
 [profile.profiling]
 inherits = "release"

--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,7 @@ bind_address = "127.0.0.1:8080"
 max_connections = 1000
 ping_interval = 30
 connection_timeout = 60
+use_reuse_port = false 
 
 [server.region]
 min_x = -1000.0

--- a/crates/game_server/Cargo.toml
+++ b/crates/game_server/Cargo.toml
@@ -13,3 +13,4 @@ tracing = { workspace = true }
 tokio-tungstenite = { workspace = true }
 horizon_event_system = { path = "../horizon_event_system" }
 plugin_system = { path = "../plugin_system" }
+socket2 = "0.5.10"

--- a/crates/game_server/Cargo.toml
+++ b/crates/game_server/Cargo.toml
@@ -13,4 +13,5 @@ tracing = { workspace = true }
 tokio-tungstenite = { workspace = true }
 horizon_event_system = { path = "../horizon_event_system" }
 plugin_system = { path = "../plugin_system" }
-socket2 = "0.5.10"
+num_cpus = { workspace = true }
+socket2 = { workspace = true }

--- a/crates/horizon/src/main.rs
+++ b/crates/horizon/src/main.rs
@@ -39,6 +39,9 @@ pub struct ServerSettings {
     pub max_connections: usize,
     /// Network timeouts
     pub connection_timeout: u64,
+
+    #[serde(default)]
+    pub use_reuse_port: bool, // Linux only flag for reusing ports
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -86,6 +89,7 @@ impl Default for AppConfig {
                 },
                 max_connections: 1000,
                 connection_timeout: 60,
+                use_reuse_port: false,
             },
             plugins: PluginSettings {
                 directory: "plugins".to_string(),
@@ -133,6 +137,7 @@ impl AppConfig {
             plugin_directory: PathBuf::from(&self.plugins.directory),
             max_connections: self.server.max_connections,
             connection_timeout: self.server.connection_timeout,
+            use_reuse_port: self.server.use_reuse_port, // Linux Only functions
         })
     }
 }
@@ -320,7 +325,7 @@ impl Application {
         }
 
         // Setup logging
-        //setup_logging(&config.logging, args.json_logs)?;
+        setup_logging(&config.logging, args.json_logs)?;
 
         // Display banner after logging is setup
         display_banner();


### PR DESCRIPTION
This pull request introduces enhancements to the server's network handling, including support for multiple acceptors using `SO_REUSEPORT`, configuration updates, and dependency additions. The changes aim to improve scalability, configurability, and maintainability of the game server.

### Network Enhancements
* Added support for multiple TCP acceptors based on CPU core count, leveraging `SO_REUSEPORT` for better scalability on supported platforms. Fallback behavior is implemented for unsupported platforms. (`crates/game_server/src/lib.rs`) [[1]](diffhunk://#diff-2a173cece5e52a3c74588c6d706fc1f10f72c0488b5872279c330378ef130239L239-R325) [[2]](diffhunk://#diff-2a173cece5e52a3c74588c6d706fc1f10f72c0488b5872279c330378ef130239R343-L276)
* Introduced a new `use_reuse_port` flag in `ServerConfig` and `ServerSettings` to enable or disable `SO_REUSEPORT`. Updated default configurations accordingly. (`crates/game_server/src/lib.rs`, `crates/horizon/src/main.rs`) [[1]](diffhunk://#diff-2a173cece5e52a3c74588c6d706fc1f10f72c0488b5872279c330378ef130239R37) [[2]](diffhunk://#diff-2a173cece5e52a3c74588c6d706fc1f10f72c0488b5872279c330378ef130239R55) [[3]](diffhunk://#diff-6358567f3120cb543dbcd0f0697857bc5597b14712cf85ce67251d0dd0b74920R42-R44) [[4]](diffhunk://#diff-6358567f3120cb543dbcd0f0697857bc5597b14712cf85ce67251d0dd0b74920R92)

### Dependency Updates
* Added `socket2` and `num_cpus` dependencies to manage low-level socket operations and determine CPU core count. (`Cargo.toml`, `crates/game_server/Cargo.toml`) [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R32-R33) [[2]](diffhunk://#diff-e49baa8104e7ed5edda688030021f229b7d382a1d62a20f95a40f71299acb3ceR16-R17)
* Updated imports in `lib.rs` to include `socket2` and `num_cpus` for the new networking logic. (`crates/game_server/src/lib.rs`)

### Logging and Debugging
* Enabled the `trace` logging level for more granular debugging of message routing errors. (`crates/game_server/src/lib.rs`)
* Fixed logging setup in the application entry point to ensure proper configuration. (`crates/horizon/src/main.rs`)

### Configuration Updates
* Added `use_reuse_port` to `config.toml` with a default value of `false`. This allows users to configure the new feature directly. (`config.toml`)