### PR TITLE
Shutdown fixes

### DIFF
--- a/crates/horizon/src/app.rs
+++ b/crates/horizon/src/app.rs
@@ -205,6 +205,17 @@ impl Application {
 
         // Wait for shutdown signal - this will update the shared shutdown state
         let signal_shutdown_state = setup_signal_handlers().await?;
+
+        // merciless shutdown
+        tokio::spawn(async move {
+            if let Err(e) = setup_signal_handlers().await {
+                error!("Failed to set up merciless shutdown signal handler: {e}");
+                return;
+            }
+
+            warn!("Shutdown handler received again! I'll make this quick.");
+            std::process::exit(1);
+        });
         
         // Transfer shutdown state to our server's shutdown state
         if signal_shutdown_state.is_shutdown_initiated() {

--- a/crates/horizon/src/app.rs
+++ b/crates/horizon/src/app.rs
@@ -292,10 +292,6 @@ impl Application {
         info!("✅ Horizon Game Server shutdown complete");
         info!("👋 Thank you for using Horizon Game Server!");
 
-        // Final safety cleanup to prevent access violations
-        // Force garbage collection and give the system time to clean up
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
-
         Ok(())
     }
 

--- a/crates/horizon/src/app.rs
+++ b/crates/horizon/src/app.rs
@@ -4,7 +4,7 @@
 //! server startup, monitoring, and shutdown with enhanced error handling
 //! and performance monitoring.
 
-use crate::{cli::CliArgs, config::AppConfig, logging::display_banner, signals::setup_signal_handlers};
+use crate::{cli::CliArgs, config::AppConfig, logging::display_banner, signals::{setup_signal_handlers, setup_signal_handlers_silent}};
 use horizon_event_system::ShutdownState;
 use game_server::GameServer;
 use tracing::{error, info, warn};
@@ -208,7 +208,7 @@ impl Application {
 
         // merciless shutdown
         tokio::spawn(async move {
-            if let Err(e) = setup_signal_handlers().await {
+            if let Err(e) = setup_signal_handlers_silent().await {
                 error!("Failed to set up merciless shutdown signal handler: {e}");
                 return;
             }

--- a/crates/horizon/src/app.rs
+++ b/crates/horizon/src/app.rs
@@ -262,6 +262,7 @@ impl Application {
         info!("🧹 Phase 3: Final cleanup - stopping server accept loops...");
         
         // Wait for server accept loops to stop gracefully
+        server_handle.abort();
         info!("⏳ Waiting for server task to complete gracefully...");
         if let Err(e) = tokio::time::timeout(
             tokio::time::Duration::from_secs(8), 


### PR DESCRIPTION
# Description

- introduce merciless shutdown: the user can send `SIGINT`/`SIGTERM`/^C twice to forcefully quit. this is essentially `SIGKILL`, but saves a sysadmin or programmer time from having to type out `kill -9 $(pidof horizon)` if horizon gets stuck
- fixes shutdown hanging for 8 seconds because `server_handle` never successfully exits. call `.abort()` on the handle to tell the tokio runtime to stop it the next time the thread `.await`s on something
- removes needless "GC" wait at end of shutdown sequence

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

ran it in a terminal. noticed no regressions

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] (N/A) I have added tests that prove my chnages are stable
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

